### PR TITLE
fixed case in included query file name queries/ec2/not_imdsV2_instances.sql

### DIFF
--- a/foundational_security/policy.hcl
+++ b/foundational_security/policy.hcl
@@ -198,7 +198,7 @@ policy "foundational_security" {
 
     check "8" {
       title = "EC2 instances should use IMDSv2"
-      query = file("queries/ec2/not_imdsV2_instances.sql")
+      query = file("queries/ec2/not_imdsv2_instances.sql")
     }
 
     check "9" {


### PR DESCRIPTION
policy.hcl includes a query using a file name with the wrong case .. works on Mac but fails on  Linux