### PR TITLE
remove group by clause causing sql error in aws lambda query

### DIFF
--- a/queries/lambda/lambda_function_prohibit_public_access.sql
+++ b/queries/lambda/lambda_function_prohibit_public_access.sql
@@ -10,6 +10,4 @@ WHERE statment ->> 'Effect' = 'Allow'
     statment-> 'Principal' ->> 'AWS' = '*'
    OR
     (statment -> 'Principal' ->> 'AWS')::jsonb ? '*'
-)
-
-GROUP BY arn;
+);


### PR DESCRIPTION
The lambda_function_prohibit_public_access.sql policy query has a group by clause, but no aggregate functions in the main select, causing the pci_dss policy check to fail when run