### PR TITLE
fix: Fixed queries related to `aws_rds_clusters` changes

### DIFF
--- a/cis_v1.2.0/policy.hcl
+++ b/cis_v1.2.0/policy.hcl
@@ -3,7 +3,7 @@ policy "cis-v1.20" {
   doc   = file("cis_v1.2.0/README.md")
   configuration {
     provider "aws" {
-      version = "~> 0.9.0"
+      version = "~> 0.10.0"
     }
   }
 

--- a/foundational_security/policy.hcl
+++ b/foundational_security/policy.hcl
@@ -2,7 +2,7 @@ policy "foundational_security" {
   title = "AWS Foundational Security Best Practices controls"
   configuration {
     provider "aws" {
-      version = "~> v0.9.0"
+      version = "~> v0.10.0"
     }
   }
 

--- a/pci_dss_v3.2.1/policy.hcl
+++ b/pci_dss_v3.2.1/policy.hcl
@@ -2,7 +2,7 @@ policy "pci-dss-v3.2.1" {
   title = "PCI DSS V3.2.1"
   configuration {
     provider "aws" {
-      version = "~> v0.9.0"
+      version = "~> v0.10.0"
     }
   }
 

--- a/policy.hcl
+++ b/policy.hcl
@@ -3,7 +3,7 @@ policy "aws" {
   doc   = file("README.md")
   configuration {
     provider "aws" {
-      version = "~> 0.9.0"
+      version = "~> 0.10.0"
     }
   }
 

--- a/public_egress/policy.hcl
+++ b/public_egress/policy.hcl
@@ -3,7 +3,7 @@ policy "public-egress" {
 
   configuration {
     provider "aws" {
-      version = "~> 0.9.0"
+      version = "~> 0.10.0"
     }
   }
   view "aws_security_group_egress_rules" {

--- a/publicly_available/policy.hcl
+++ b/publicly_available/policy.hcl
@@ -3,7 +3,7 @@ policy "public-ips" {
 
   configuration {
     provider "aws" {
-      version = "~> 0.9.0"
+      version = "~> 0.10.0"
     }
   }
 

--- a/queries/autoscaling/autoscaling_groups_elb_check.sql
+++ b/queries/autoscaling/autoscaling_groups_elb_check.sql
@@ -1,4 +1,3 @@
 SELECT account_id, region, arn, name
 FROM aws_autoscaling_groups
-WHERE ARRAY_LENGTH(load_balancer_names, 1) > 0
-  AND health_check_type IS DISTINCT FROM 'ELB';
+WHERE ARRAY_LENGTH(load_balancer_names, 1) > 0 AND health_check_type IS DISTINCT FROM 'ELB';

--- a/queries/autoscaling/autoscaling_groups_elb_check.sql
+++ b/queries/autoscaling/autoscaling_groups_elb_check.sql
@@ -1,4 +1,4 @@
-SELECT "account_id", "region", "arn", "name"
+SELECT account_id, region, arn, name
 FROM aws_autoscaling_groups
-WHERE array_length("load_balancer_names", 1) > 0
-    AND "health_check_type" IS DISTINCT FROM 'ELB'
+WHERE ARRAY_LENGTH(load_balancer_names, 1) > 0
+  AND health_check_type IS DISTINCT FROM 'ELB';

--- a/queries/codebuild/check_environment_variables.sql
+++ b/queries/codebuild/check_environment_variables.sql
@@ -1,8 +1,8 @@
 SELECT DISTINCT p.account_id, p.region, p.name
 FROM aws_codebuild_projects p
-    JOIN aws_codebuild_project_environment_variables e ON
-        p.cq_id = e.project_cq_id
-WHERE e."type" = 'PLAINTEXT'
-    AND (UPPER(e.name) LIKE '%ACCESS_KEY%'
-        OR UPPER(e.name) LIKE '%SECRET%'
-        OR UPPER(e.name) LIKE '%PASSWORD%');
+         JOIN aws_codebuild_project_environment_variables e ON
+    p.cq_id = e.project_cq_id
+WHERE e.type = 'PLAINTEXT'
+  AND (UPPER(e.name) LIKE '%ACCESS_KEY%'
+    OR UPPER(e.name) LIKE '%SECRET%'
+    OR UPPER(e.name) LIKE '%PASSWORD%');

--- a/queries/codebuild/check_environment_variables.sql
+++ b/queries/codebuild/check_environment_variables.sql
@@ -1,8 +1,6 @@
 SELECT DISTINCT p.account_id, p.region, p.name
 FROM aws_codebuild_projects p
-         JOIN aws_codebuild_project_environment_variables e ON
+     JOIN aws_codebuild_project_environment_variables e ON
     p.cq_id = e.project_cq_id
 WHERE e.type = 'PLAINTEXT'
-  AND (UPPER(e.name) LIKE '%ACCESS_KEY%'
-    OR UPPER(e.name) LIKE '%SECRET%'
-    OR UPPER(e.name) LIKE '%PASSWORD%');
+      AND (UPPER(e.name) LIKE '%ACCESS_KEY%' OR UPPER(e.name) LIKE '%SECRET%' OR UPPER(e.name) LIKE '%PASSWORD%');

--- a/queries/cq_views/api_gateway_method_settings.sql
+++ b/queries/cq_views/api_gateway_method_settings.sql
@@ -1,14 +1,14 @@
 SELECT cq_id,
        stage_name,
        rest_api_cq_id,
-       tracing_enabled                                      AS stage_data_trace_enabled,
-       cache_cluster_enabled                                AS stage_caching_enabled,
-       web_acl_arn                                          AS waf,
-       client_certificate_id                                AS cert,
-       key                                                  AS method,
-       (value :: JSON -> 'DataTraceEnabled')::TEXT::BOOLEAN AS data_trace_enabled,
-       (value::JSON -> 'CachingEnabled')::TEXT::BOOLEAN     AS caching_enabled,
+       tracing_enabled AS stage_data_trace_enabled,
+       cache_cluster_enabled AS stage_caching_enabled,
+       web_acl_arn AS waf,
+       client_certificate_id AS cert,
+       key AS method,
+       (value::JSON -> 'DataTraceEnabled')::TEXT::BOOLEAN AS data_trace_enabled,
+       (value::JSON -> 'CachingEnabled')::TEXT::BOOLEAN AS caching_enabled,
        (value::JSON -> 'CacheDataEncrypted')::TEXT::BOOLEAN AS cache_data_encrypted,
-       (value::JSON -> 'LoggingLevel')::TEXT                AS logging_level
+       (value::JSON -> 'LoggingLevel')::TEXT AS logging_level
 FROM aws_apigateway_rest_api_stages,
     JSONB_EACH_TEXT(aws_apigateway_rest_api_stages.method_settings)

--- a/queries/cq_views/api_gateway_method_settings.sql
+++ b/queries/cq_views/api_gateway_method_settings.sql
@@ -1,19 +1,14 @@
-SELECT
-    cq_id,
-    stage_name,
-    rest_api_cq_id,
-    tracing_enabled AS stage_data_trace_enabled,
-    cache_cluster_enabled AS stage_caching_enabled,
-    web_acl_arn AS waf,
-    client_certificate_id AS cert,
-    key AS method,
-    (value :: JSON -> 'DataTraceEnabled')::TEXT::BOOLEAN AS data_trace_enabled,
-    (value::JSON -> 'CachingEnabled')::TEXT::BOOLEAN AS caching_enabled,
-    (
-        value::JSON -> 'CacheDataEncrypted'
-    )::TEXT::BOOLEAN AS cache_data_encrypted,
-    (value::JSON -> 'LoggingLevel')::TEXT AS logging_level
-
-FROM
-    aws_apigateway_rest_api_stages,
-    jsonb_each_text(aws_apigateway_rest_api_stages.method_settings)
+SELECT cq_id,
+       stage_name,
+       rest_api_cq_id,
+       tracing_enabled                                      AS stage_data_trace_enabled,
+       cache_cluster_enabled                                AS stage_caching_enabled,
+       web_acl_arn                                          AS waf,
+       client_certificate_id                                AS cert,
+       key                                                  AS method,
+       (value :: JSON -> 'DataTraceEnabled')::TEXT::BOOLEAN AS data_trace_enabled,
+       (value::JSON -> 'CachingEnabled')::TEXT::BOOLEAN     AS caching_enabled,
+       (value::JSON -> 'CacheDataEncrypted')::TEXT::BOOLEAN AS cache_data_encrypted,
+       (value::JSON -> 'LoggingLevel')::TEXT                AS logging_level
+FROM aws_apigateway_rest_api_stages,
+    JSONB_EACH_TEXT(aws_apigateway_rest_api_stages.method_settings)

--- a/queries/dynamodb/autoscale_or_ondemand.sql
+++ b/queries/dynamodb/autoscale_or_ondemand.sql
@@ -1,26 +1,29 @@
-SELECT
-    t.account_id, t.region, t.id, t.name, t.arn, pr.type
+SELECT t.account_id,
+       t.region,
+       t.id,
+       t.name,
+       t.arn,
+       pr.type
 FROM aws_dynamodb_tables t
-    LEFT JOIN
-        aws_dynamodb_table_replica_auto_scalings s ON s.table_cq_id = t.cq_id
-    LEFT JOIN
-        aws_applicationautoscaling_policies pr ON pr.namespace = 'dynamodb'
-            AND pr.resource_id = CONCAT('table/', t.name)
-            AND pr.type = 'TargetTrackingScaling'
-            AND pr.scalable_dimension = 'dynamodb:table:ReadCapacityUnits'
-    LEFT JOIN
-        aws_applicationautoscaling_policies pw ON pw.namespace = 'dynamodb'
-            AND pw.resource_id = CONCAT('table/', t.name)
-            AND pw.type = 'TargetTrackingScaling'
-            AND pw.scalable_dimension = 'dynamodb:table:WriteCapacityUnits'
-WHERE
-    (t.billing_mode_summary -> 'billing_mode')::VARCHAR IS DISTINCT
+         LEFT JOIN
+     aws_dynamodb_table_replica_auto_scalings s ON s.table_cq_id = t.cq_id
+         LEFT JOIN
+     aws_applicationautoscaling_policies pr ON pr.namespace = 'dynamodb'
+         AND pr.resource_id = CONCAT('table/', t.name)
+         AND pr.type = 'TargetTrackingScaling'
+         AND pr.scalable_dimension = 'dynamodb:table:ReadCapacityUnits'
+         LEFT JOIN
+     aws_applicationautoscaling_policies pw ON pw.namespace = 'dynamodb'
+         AND pw.resource_id = CONCAT('table/', t.name)
+         AND pw.type = 'TargetTrackingScaling'
+         AND pw.scalable_dimension = 'dynamodb:table:WriteCapacityUnits'
+WHERE (t.billing_mode_summary -> 'billing_mode')::VARCHAR IS DISTINCT
     FROM 'PAY_PER_REQUEST'
-    AND (
-        s.read_capacity -> 'auto_scaling_disabled' IS NULL
+  AND (
+            s.read_capacity -> 'auto_scaling_disabled' IS NULL
         OR (s.read_capacity -> 'auto_scaling_disabled') IS DISTINCT FROM 'false'
         OR s.write_capacity -> 'auto_scaling_disabled' IS NULL
         OR (s.write_capacity -> 'auto_scaling_disabled') IS DISTINCT
         FROM 'false'
     )
-    AND (pr.cq_id IS NULL OR pw.cq_id IS NULL)
+  AND (pr.cq_id IS NULL OR pw.cq_id IS NULL);

--- a/queries/dynamodb/autoscale_or_ondemand.sql
+++ b/queries/dynamodb/autoscale_or_ondemand.sql
@@ -5,25 +5,22 @@ SELECT t.account_id,
        t.arn,
        pr.type
 FROM aws_dynamodb_tables t
-         LEFT JOIN
-     aws_dynamodb_table_replica_auto_scalings s ON s.table_cq_id = t.cq_id
-         LEFT JOIN
-     aws_applicationautoscaling_policies pr ON pr.namespace = 'dynamodb'
-         AND pr.resource_id = CONCAT('table/', t.name)
-         AND pr.type = 'TargetTrackingScaling'
-         AND pr.scalable_dimension = 'dynamodb:table:ReadCapacityUnits'
-         LEFT JOIN
-     aws_applicationautoscaling_policies pw ON pw.namespace = 'dynamodb'
-         AND pw.resource_id = CONCAT('table/', t.name)
-         AND pw.type = 'TargetTrackingScaling'
-         AND pw.scalable_dimension = 'dynamodb:table:WriteCapacityUnits'
+    LEFT JOIN aws_dynamodb_table_replica_auto_scalings s ON s.table_cq_id = t.cq_id
+    LEFT JOIN aws_applicationautoscaling_policies pr ON (pr.namespace = 'dynamodb'
+        AND pr.resource_id = CONCAT('table/', t.name)
+        AND pr.type = 'TargetTrackingScaling'
+        AND pr.scalable_dimension = 'dynamodb:table:ReadCapacityUnits')
+    LEFT JOIN aws_applicationautoscaling_policies pw ON (pw.namespace = 'dynamodb'
+        AND pw.resource_id = CONCAT('table/', t.name)
+        AND pw.type = 'TargetTrackingScaling'
+        AND pw.scalable_dimension = 'dynamodb:table:WriteCapacityUnits')
 WHERE (t.billing_mode_summary -> 'billing_mode')::VARCHAR IS DISTINCT
     FROM 'PAY_PER_REQUEST'
-  AND (
-            s.read_capacity -> 'auto_scaling_disabled' IS NULL
+    AND (
+        s.read_capacity -> 'auto_scaling_disabled' IS NULL
         OR (s.read_capacity -> 'auto_scaling_disabled') IS DISTINCT FROM 'false'
         OR s.write_capacity -> 'auto_scaling_disabled' IS NULL
         OR (s.write_capacity -> 'auto_scaling_disabled') IS DISTINCT
         FROM 'false'
     )
-  AND (pr.cq_id IS NULL OR pw.cq_id IS NULL);
+    AND (pr.cq_id IS NULL OR pw.cq_id IS NULL);

--- a/queries/ec2/ebs_snapshot_permissions_check.sql
+++ b/queries/ec2/ebs_snapshot_permissions_check.sql
@@ -1,18 +1,17 @@
 WITH snapshot_access_groups AS (
-    SELECT
-        account_id,
-        region,
-        snapshot_id,
-        jsonb_array_elements(create_volume_permissions) ->> 'group' AS "group",
-        jsonb_array_elements(
-            create_volume_permissions
-        ) ->> 'user_id' AS "user_id"
+    SELECT account_id,
+           region,
+           snapshot_id,
+           JSONB_ARRAY_ELEMENTS(create_volume_permissions) ->> 'group' AS "group",
+           JSONB_ARRAY_ELEMENTS(
+                   create_volume_permissions
+               ) ->> 'user_id'                                         AS user_id
     FROM aws_ec2_ebs_snapshots
 )
 
 SELECT DISTINCT *
 FROM snapshot_access_groups
 WHERE "group" = 'all'
-    -- this is under question because
-    -- trusted accounts(user_id) do not violate this control
-    OR user_id IS DISTINCT FROM '';
+   -- this is under question because
+   -- trusted accounts(user_id) do not violate this control
+   OR user_id IS DISTINCT FROM '';

--- a/queries/ec2/ebs_snapshot_permissions_check.sql
+++ b/queries/ec2/ebs_snapshot_permissions_check.sql
@@ -3,9 +3,7 @@ WITH snapshot_access_groups AS (
            region,
            snapshot_id,
            JSONB_ARRAY_ELEMENTS(create_volume_permissions) ->> 'group' AS "group",
-           JSONB_ARRAY_ELEMENTS(
-                   create_volume_permissions
-               ) ->> 'user_id'                                         AS user_id
+           JSONB_ARRAY_ELEMENTS(create_volume_permissions) ->> 'user_id' AS user_id
     FROM aws_ec2_ebs_snapshots
 )
 
@@ -14,4 +12,4 @@ FROM snapshot_access_groups
 WHERE "group" = 'all'
    -- this is under question because
    -- trusted accounts(user_id) do not violate this control
-   OR user_id IS DISTINCT FROM '';
+      OR user_id IS DISTINCT FROM '';

--- a/queries/ec2/sgs_all_access_to_port_22.sql
+++ b/queries/ec2/sgs_all_access_to_port_22.sql
@@ -1,50 +1,39 @@
 /* Find Security groups that give access to ipv4 addresses */
 SELECT t.arn
 FROM (
-         SELECT
-             /* create arn for sg */
-             arn,
-             /* Calculate total number of IPs a SG rule gives access to */
-             (
-                         SPLIT_PART(
-                                 HOST(BROADCAST(cidr_ip::CIDR)), '.', 1
-                             )::BIGINT * 16777216 + SPLIT_PART(
-                                                            HOST(BROADCAST(cidr_ip::CIDR)), '.', 2
-                                                        )::BIGINT * 65536 + SPLIT_PART(
-                                                                                    HOST(BROADCAST(cidr_ip::CIDR)),
-                                                                                    '.', 3
-                                                                                )::BIGINT * 256 + SPLIT_PART(
-                                 HOST(BROADCAST(cidr_ip::CIDR)), '.', 4
-                             )::BIGINT
-                 ) - (
-                         SPLIT_PART(
-                                 HOST(cidr_ip::CIDR), '.', 1
-                             )::BIGINT * 16777216 + SPLIT_PART(
-                                                            HOST(cidr_ip::CIDR), '.', 2
-                                                        )::BIGINT * 65536 + SPLIT_PART(
-                                                                                    HOST(cidr_ip::CIDR), '.', 3
-                                                                                )::BIGINT * 256 + SPLIT_PART(
-                                 HOST(cidr_ip::CIDR), '.', 4
-                             )::BIGINT
-                 ) AS totalIps
-         FROM aws_ec2_security_groups
-                  JOIN
-              aws_ec2_security_group_ip_permissions ON
-                      aws_ec2_security_groups.cq_id =
-                      aws_ec2_security_group_ip_permissions.security_group_cq_id
-                  JOIN
-              aws_ec2_security_group_ip_permission_ip_ranges ON
-                      aws_ec2_security_group_ip_permissions.cq_id =
-                      aws_ec2_security_group_ip_permission_ip_ranges.security_group_ip_permission_cq_id
-         WHERE (
-                       (
-                               from_port IS NULL
-                               AND to_port IS NULL
-                           )
-                       OR 22 BETWEEN from_port
-                           AND to_port
-                   )
-     ) AS t
+    SELECT
+        /* create arn for sg */
+        arn,
+        /* Calculate total number of IPs a SG rule gives access to */
+        (
+            SPLIT_PART(HOST(BROADCAST(cidr_ip::CIDR)), '.', 1)::BIGINT * 16777216
+            + SPLIT_PART(HOST(BROADCAST(cidr_ip::CIDR)), '.', 2)::BIGINT * 65536
+            + SPLIT_PART(HOST(BROADCAST(cidr_ip::CIDR)), '.', 3)::BIGINT * 256
+            + SPLIT_PART(HOST(BROADCAST(cidr_ip::CIDR)), '.', 4)::BIGINT
+        ) - (
+            SPLIT_PART(HOST(cidr_ip::CIDR), '.', 1)::BIGINT * 16777216
+            + SPLIT_PART(HOST(cidr_ip::CIDR), '.', 2)::BIGINT * 65536
+            + SPLIT_PART(HOST(cidr_ip::CIDR), '.', 3)::BIGINT * 256
+            + SPLIT_PART(HOST(cidr_ip::CIDR), '.', 4)::BIGINT
+        ) AS totalIps
+    FROM aws_ec2_security_groups
+        JOIN
+            aws_ec2_security_group_ip_permissions ON
+                aws_ec2_security_groups.cq_id =
+                aws_ec2_security_group_ip_permissions.security_group_cq_id
+        JOIN
+            aws_ec2_security_group_ip_permission_ip_ranges ON
+                aws_ec2_security_group_ip_permissions.cq_id =
+                aws_ec2_security_group_ip_permission_ip_ranges.security_group_ip_permission_cq_id
+    WHERE (
+            (
+                from_port IS NULL
+                AND to_port IS NULL
+            )
+            OR 22 BETWEEN from_port
+            AND to_port
+        )
+) AS t
 GROUP BY t.arn
 HAVING SUM(t.totalIps) = 4294967295
 /* this value is the total number of ips in ipv4 space ie 0.0.0.0/0 */
@@ -52,35 +41,35 @@ UNION
 /* Find Security groups that give access to ipv6 addresses */
 SELECT t.arn
 FROM (
-         SELECT
-             /* create arn for sg */
-             arn,
-             /* Calculate total number of IPs a SG rule gives access to */
-             ROUND(
-                         2 ^ (
-                             128 - MASKLEN(
-                                 aws_ec2_security_group_ip_permission_ipv6_ranges.cidr_ipv6::CIDR
-                             )
-                         )::NUMERIC
-                 ) AS totalIps
-         FROM aws_ec2_security_groups
-                  JOIN
-              aws_ec2_security_group_ip_permissions ON
-                      aws_ec2_security_groups.cq_id =
-                      aws_ec2_security_group_ip_permissions.security_group_cq_id
-                  JOIN
-              aws_ec2_security_group_ip_permission_ipv6_ranges ON
-                      aws_ec2_security_group_ip_permissions.cq_id =
-                      aws_ec2_security_group_ip_permission_ipv6_ranges.security_group_ip_permission_cq_id
-         WHERE (
-                       (
-                               from_port IS NULL
-                               AND to_port IS NULL
-                           )
-                       OR 22 BETWEEN from_port
-                           AND to_port
-                   )
-     ) AS t
+        SELECT
+            /* create arn for sg */
+            arn,
+            /* Calculate total number of IPs a SG rule gives access to */
+            ROUND(
+                2 ^ (
+                    128 - MASKLEN(
+                        aws_ec2_security_group_ip_permission_ipv6_ranges.cidr_ipv6::CIDR
+                    )
+                )::NUMERIC
+            ) AS totalIps
+        FROM aws_ec2_security_groups
+            JOIN
+                aws_ec2_security_group_ip_permissions ON
+                    aws_ec2_security_groups.cq_id =
+                    aws_ec2_security_group_ip_permissions.security_group_cq_id
+            JOIN
+                aws_ec2_security_group_ip_permission_ipv6_ranges ON
+                    aws_ec2_security_group_ip_permissions.cq_id =
+                    aws_ec2_security_group_ip_permission_ipv6_ranges.security_group_ip_permission_cq_id
+        WHERE (
+                (
+                    from_port IS NULL
+                    AND to_port IS NULL
+                )
+                OR 22 BETWEEN from_port
+                AND to_port
+            )
+    ) AS t
 GROUP BY t.arn
 HAVING SUM(t.totalIps) = 340282366920938463463374607431768211456;
 

--- a/queries/ec2/sgs_all_access_to_port_22.sql
+++ b/queries/ec2/sgs_all_access_to_port_22.sql
@@ -1,98 +1,87 @@
 /* Find Security groups that give access to ipv4 addresses */
-SELECT
-    t.arn
-FROM
-    (
-        SELECT
-            /* create arn for sg */
-            arn,
-            /* Calculate total number of IPs a SG rule gives access to */
-            (
-                split_part(
-                    host(broadcast(cidr_ip :: CIDR)), '.', 1
-                ) :: BIGINT * 16777216 + split_part(
-                    host(broadcast(cidr_ip :: CIDR)), '.', 2
-                ) :: BIGINT * 65536 + split_part(
-                    host(broadcast(cidr_ip :: CIDR)), '.', 3
-                ) :: BIGINT * 256 + split_part(
-                    host(broadcast(cidr_ip :: CIDR)), '.', 4
-                ) :: BIGINT
-            ) - (
-                split_part(
-                    host(cidr_ip :: CIDR), '.', 1
-                ) :: BIGINT * 16777216 + split_part(
-                    host(cidr_ip :: CIDR), '.', 2
-                ) :: BIGINT * 65536 + split_part(
-                    host(cidr_ip :: CIDR), '.', 3
-                ) :: BIGINT * 256 + split_part(
-                    host(cidr_ip :: CIDR), '.', 4
-                ) :: BIGINT
-            ) AS totalIps
-        FROM
-            aws_ec2_security_groups
-            JOIN
-                aws_ec2_security_group_ip_permissions ON
-                    aws_ec2_security_groups.cq_id =
-                    aws_ec2_security_group_ip_permissions.security_group_cq_id
-            JOIN
-                aws_ec2_security_group_ip_permission_ip_ranges ON
-                    aws_ec2_security_group_ip_permissions.cq_id =
-                    aws_ec2_security_group_ip_permission_ip_ranges.security_group_ip_permission_cq_id
-        WHERE
-            (
-                (
-                    from_port IS NULL
-                    AND to_port IS NULL
-                )
-                OR 22 BETWEEN from_port
-                AND to_port
-            )
-    ) AS t
-GROUP BY
-    t.arn
-HAVING
-    sum(t.totalIps) = 4294967295
+SELECT t.arn
+FROM (
+         SELECT
+             /* create arn for sg */
+             arn,
+             /* Calculate total number of IPs a SG rule gives access to */
+             (
+                         SPLIT_PART(
+                                 HOST(BROADCAST(cidr_ip::CIDR)), '.', 1
+                             )::BIGINT * 16777216 + SPLIT_PART(
+                                                            HOST(BROADCAST(cidr_ip::CIDR)), '.', 2
+                                                        )::BIGINT * 65536 + SPLIT_PART(
+                                                                                    HOST(BROADCAST(cidr_ip::CIDR)),
+                                                                                    '.', 3
+                                                                                )::BIGINT * 256 + SPLIT_PART(
+                                 HOST(BROADCAST(cidr_ip::CIDR)), '.', 4
+                             )::BIGINT
+                 ) - (
+                         SPLIT_PART(
+                                 HOST(cidr_ip::CIDR), '.', 1
+                             )::BIGINT * 16777216 + SPLIT_PART(
+                                                            HOST(cidr_ip::CIDR), '.', 2
+                                                        )::BIGINT * 65536 + SPLIT_PART(
+                                                                                    HOST(cidr_ip::CIDR), '.', 3
+                                                                                )::BIGINT * 256 + SPLIT_PART(
+                                 HOST(cidr_ip::CIDR), '.', 4
+                             )::BIGINT
+                 ) AS totalIps
+         FROM aws_ec2_security_groups
+                  JOIN
+              aws_ec2_security_group_ip_permissions ON
+                      aws_ec2_security_groups.cq_id =
+                      aws_ec2_security_group_ip_permissions.security_group_cq_id
+                  JOIN
+              aws_ec2_security_group_ip_permission_ip_ranges ON
+                      aws_ec2_security_group_ip_permissions.cq_id =
+                      aws_ec2_security_group_ip_permission_ip_ranges.security_group_ip_permission_cq_id
+         WHERE (
+                       (
+                               from_port IS NULL
+                               AND to_port IS NULL
+                           )
+                       OR 22 BETWEEN from_port
+                           AND to_port
+                   )
+     ) AS t
+GROUP BY t.arn
+HAVING SUM(t.totalIps) = 4294967295
 /* this value is the total number of ips in ipv4 space ie 0.0.0.0/0 */
 UNION
 /* Find Security groups that give access to ipv6 addresses */
-SELECT
-    t.arn
-FROM
-    (
-        SELECT
-            /* create arn for sg */
-            arn,
-            /* Calculate total number of IPs a SG rule gives access to */
-            round(
-                2 ^ (
-                    128 - masklen(
-                        aws_ec2_security_group_ip_permission_ipv6_ranges.cidr_ipv6 :: CIDR
-                    )
-                ) :: NUMERIC
-            ) AS totalIps
-        FROM
-            aws_ec2_security_groups
-            JOIN
-                aws_ec2_security_group_ip_permissions ON
-                    aws_ec2_security_groups.cq_id =
-                    aws_ec2_security_group_ip_permissions.security_group_cq_id
-            JOIN
-                aws_ec2_security_group_ip_permission_ipv6_ranges ON
-                    aws_ec2_security_group_ip_permissions.cq_id =
-                    aws_ec2_security_group_ip_permission_ipv6_ranges.security_group_ip_permission_cq_id
-        WHERE
-            (
-                (
-                    from_port IS NULL
-                    AND to_port IS NULL
-                )
-                OR 22 BETWEEN from_port
-                AND to_port
-            )
-    ) AS t
-GROUP BY
-    t.arn
-HAVING
-    sum(t.totalIps) = 340282366920938463463374607431768211456;
+SELECT t.arn
+FROM (
+         SELECT
+             /* create arn for sg */
+             arn,
+             /* Calculate total number of IPs a SG rule gives access to */
+             ROUND(
+                         2 ^ (
+                             128 - MASKLEN(
+                                 aws_ec2_security_group_ip_permission_ipv6_ranges.cidr_ipv6::CIDR
+                             )
+                         )::NUMERIC
+                 ) AS totalIps
+         FROM aws_ec2_security_groups
+                  JOIN
+              aws_ec2_security_group_ip_permissions ON
+                      aws_ec2_security_groups.cq_id =
+                      aws_ec2_security_group_ip_permissions.security_group_cq_id
+                  JOIN
+              aws_ec2_security_group_ip_permission_ipv6_ranges ON
+                      aws_ec2_security_group_ip_permissions.cq_id =
+                      aws_ec2_security_group_ip_permission_ipv6_ranges.security_group_ip_permission_cq_id
+         WHERE (
+                       (
+                               from_port IS NULL
+                               AND to_port IS NULL
+                           )
+                       OR 22 BETWEEN from_port
+                           AND to_port
+                   )
+     ) AS t
+GROUP BY t.arn
+HAVING SUM(t.totalIps) = 340282366920938463463374607431768211456;
 
 /* this value is the total number of ips in ipv6 space ie ::/0 */

--- a/queries/iam/no_star.sql
+++ b/queries/iam/no_star.sql
@@ -1,44 +1,38 @@
 WITH violations AS (
-    SELECT
-        policy_cq_id,
-        count(*) AS violations
-    FROM
-        aws_iam_policy_versions,
-        jsonb_array_elements(document -> 'Statement') AS statement,
-        jsonb_array_elements_text(
-            CASE jsonb_typeof(
-                statement -> 'Resource'
-            )
-                WHEN
-                    'string' THEN jsonb_build_array(statement ->> 'Resource')
-                WHEN 'array' THEN statement -> 'Resource'
-            END
-        ) AS resource,
-        jsonb_array_elements_text(
-            CASE jsonb_typeof(
-                statement -> 'Action'
-            )
-                WHEN
-                    'string' THEN jsonb_build_array(statement ->> 'Action')
-                WHEN 'array' THEN statement -> 'Action'
-            END
-        ) AS action
-    WHERE
-        statement ->> 'Effect' = 'Allow'
-        AND resource = '*'
-        AND (
-            action = '*'
+    SELECT policy_cq_id,
+           COUNT(*) AS violations
+    FROM aws_iam_policy_versions,
+         JSONB_ARRAY_ELEMENTS(document -> 'Statement') AS statement,
+         JSONB_ARRAY_ELEMENTS_TEXT(
+                 CASE JSONB_TYPEOF(
+                         statement -> 'Resource'
+                     )
+                     WHEN
+                         'string' THEN JSONB_BUILD_ARRAY(statement ->> 'Resource')
+                     WHEN 'array' THEN statement -> 'Resource'
+                     END
+             ) AS resource,
+         JSONB_ARRAY_ELEMENTS_TEXT(
+                 CASE JSONB_TYPEOF(
+                         statement -> 'Action'
+                     )
+                     WHEN
+                         'string' THEN JSONB_BUILD_ARRAY(statement ->> 'Action')
+                     WHEN 'array' THEN statement -> 'Action'
+                     END
+             ) AS action
+    WHERE statement ->> 'Effect' = 'Allow'
+      AND resource = '*'
+      AND (
+                action = '*'
             OR action = '*:*'
         )
-    GROUP BY
-        policy_cq_id
+    GROUP BY policy_cq_id
 )
-SELECT
-    account_id,
-    arn,
-    id,
-    name,
-    violations
-FROM
-    aws_iam_policies
-    JOIN violations ON violations.policy_cq_id = aws_iam_policies.cq_id
+SELECT account_id,
+       arn,
+       id,
+       name,
+       violations
+FROM aws_iam_policies
+         JOIN violations ON violations.policy_cq_id = aws_iam_policies.cq_id

--- a/queries/iam/no_star.sql
+++ b/queries/iam/no_star.sql
@@ -2,31 +2,19 @@ WITH violations AS (
     SELECT policy_cq_id,
            COUNT(*) AS violations
     FROM aws_iam_policy_versions,
-         JSONB_ARRAY_ELEMENTS(document -> 'Statement') AS statement,
-         JSONB_ARRAY_ELEMENTS_TEXT(
-                 CASE JSONB_TYPEOF(
-                         statement -> 'Resource'
-                     )
-                     WHEN
-                         'string' THEN JSONB_BUILD_ARRAY(statement ->> 'Resource')
-                     WHEN 'array' THEN statement -> 'Resource'
-                     END
-             ) AS resource,
-         JSONB_ARRAY_ELEMENTS_TEXT(
-                 CASE JSONB_TYPEOF(
-                         statement -> 'Action'
-                     )
-                     WHEN
-                         'string' THEN JSONB_BUILD_ARRAY(statement ->> 'Action')
-                     WHEN 'array' THEN statement -> 'Action'
-                     END
-             ) AS action
+        JSONB_ARRAY_ELEMENTS(document -> 'Statement') AS statement,
+        JSONB_ARRAY_ELEMENTS_TEXT(
+            CASE JSONB_TYPEOF(statement -> 'Resource')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(statement ->> 'Resource')
+                WHEN 'array' THEN statement -> 'Resource' END
+        ) AS resource,
+        JSONB_ARRAY_ELEMENTS_TEXT( CASE JSONB_TYPEOF(statement -> 'Action')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(statement ->> 'Action')
+                WHEN 'array' THEN statement -> 'Action' END
+        ) AS action
     WHERE statement ->> 'Effect' = 'Allow'
-      AND resource = '*'
-      AND (
-                action = '*'
-            OR action = '*:*'
-        )
+          AND resource = '*'
+          AND ( action = '*' OR action = '*:*' )
     GROUP BY policy_cq_id
 )
 SELECT account_id,
@@ -35,4 +23,4 @@ SELECT account_id,
        name,
        violations
 FROM aws_iam_policies
-         JOIN violations ON violations.policy_cq_id = aws_iam_policies.cq_id
+     JOIN violations ON violations.policy_cq_id = aws_iam_policies.cq_id

--- a/queries/rds/amazon_aurora_clusters_should_have_backtracking_enabled.sql
+++ b/queries/rds/amazon_aurora_clusters_should_have_backtracking_enabled.sql
@@ -1,4 +1,4 @@
-SELECT db_cluster_arn
+SELECT arn
 FROM aws_rds_clusters
 WHERE
     engine IN ('aurora', 'aurora-mysql', 'mysql')

--- a/queries/rds/iam_authentication_should_be_configured_for_rds_clusters.sql
+++ b/queries/rds/iam_authentication_should_be_configured_for_rds_clusters.sql
@@ -1,3 +1,3 @@
-SELECT db_cluster_arn
+SELECT arn
 FROM aws_rds_clusters
 WHERE iam_database_authentication_enabled IS NOT TRUE

--- a/queries/rds/rds_clusters_should_have_deletion_protection_enabled.sql
+++ b/queries/rds/rds_clusters_should_have_deletion_protection_enabled.sql
@@ -1,3 +1,3 @@
-SELECT db_cluster_arn
+SELECT arn
 FROM aws_rds_clusters
 WHERE deletion_protection IS NOT TRUE

--- a/queries/rds/rds_databases_and_clusters_should_not_use_a_database_engine_default_port.sql
+++ b/queries/rds/rds_databases_and_clusters_should_not_use_a_database_engine_default_port.sql
@@ -1,5 +1,5 @@
 (
-    SELECT db_cluster_arn
+    SELECT arn
     FROM aws_rds_clusters
     WHERE
         (engine IN ('aurora', 'aurora-mysql', 'mysql') AND port = 3306)

--- a/queries/rds/rds_db_clusters_should_be_configured_for_multiple_availability_zones.sql
+++ b/queries/rds/rds_db_clusters_should_be_configured_for_multiple_availability_zones.sql
@@ -1,3 +1,3 @@
-SELECT db_cluster_arn
+SELECT arn
 FROM aws_rds_clusters
 WHERE multi_az IS NOT TRUE

--- a/queries/rds/rds_db_clusters_should_be_configured_to_copy_tags_to_snapshots.sql
+++ b/queries/rds/rds_db_clusters_should_be_configured_to_copy_tags_to_snapshots.sql
@@ -1,3 +1,3 @@
-SELECT db_cluster_arn
+SELECT arn
 FROM aws_rds_clusters
 WHERE copy_tags_to_snapshot IS NOT TRUE

--- a/queries/rds/rds_event_notifications_subscription_should_be_configured_for_critical_cluster_events.sql
+++ b/queries/rds/rds_event_notifications_subscription_should_be_configured_for_critical_cluster_events.sql
@@ -22,7 +22,7 @@ WITH any_category AS (
     GROUP BY source_id
 )
 SELECT
-    db_cluster_arn
+    arn
 FROM
     aws_rds_clusters
     LEFT OUTER JOIN any_category ON TRUE

--- a/queries/s3/deny_http_requests.sql
+++ b/queries/s3/deny_http_requests.sql
@@ -25,11 +25,11 @@ WHERE
         WHERE
             principals = '"*"'
             OR (
-                principals :: JSONB ? 'AWS'
+                principals::JSONB ? 'AWS'
                 AND (
                     principals -> 'AWS' = '"*"'
                     OR principals -> 'AWS' @> '"*"'
                 )
             )
-            AND ssl :: BOOL = FALSE
+            AND ssl::BOOL = FALSE
     );

--- a/queries/s3/publicly_readable_buckets.sql
+++ b/queries/s3/publicly_readable_buckets.sql
@@ -29,7 +29,7 @@ FROM
         WHERE
             principals = '"*"'
             OR (
-                principals :: JSONB ? 'AWS'
+                principals::JSONB ? 'AWS'
                 AND (
                     principals -> 'AWS' = '"*"'
                     OR principals -> 'AWS' @> '"*"'

--- a/queries/s3/publicly_writable_buckets.sql
+++ b/queries/s3/publicly_writable_buckets.sql
@@ -29,7 +29,7 @@ FROM
         WHERE
             principals = '"*"'
             OR (
-                principals :: JSONB ? 'AWS'
+                principals::JSONB ? 'AWS'
                 AND (
                     principals -> 'AWS' = '"*"'
                     OR principals -> 'AWS' @> '"*"'

--- a/queries/s3/restrict_cross_account_actions.sql
+++ b/queries/s3/restrict_cross_account_actions.sql
@@ -1,52 +1,53 @@
 SELECT arn,
+       account_id,
+       a.value::TEXT AS ACTION,
+       p.value::TEXT AS USER --noqa
+FROM (SELECT aws_s3_buckets.arn,
     account_id,
-    a.value::TEXT AS action,
-    p.value::TEXT AS user --noqa
-FROM
-    (SELECT aws_s3_buckets.arn,
-            account_id,
-            -- For each Statement return an array containing the prinicipals
-            CASE
-                WHEN
-                    JSONB_TYPEOF(
-                        statements -> 'Principal'
-                    ) = 'string' THEN JSONB_BUILD_ARRAY(
-                        statements -> 'Principal'
-                    )
-                WHEN
-                    JSONB_TYPEOF(
-                        statements -> 'Principal' -> 'AWS'
-                    ) = 'string' THEN JSONB_BUILD_ARRAY(
-                        statements -> 'Principal' -> 'AWS'
-                    )
-                WHEN
-                    JSONB_TYPEOF(
-                        statements -> 'Principal' -> 'AWS'
-                    ) = 'array' THEN statements -> 'Principal' -> 'AWS'
-           END AS principals,
-            -- For each Statement return an array containing the Actions
-            CASE
-                WHEN
-                    JSONB_TYPEOF(
-                        statements -> 'Action'
-                    ) = 'string' THEN JSONB_BUILD_ARRAY(statements -> 'Action')
-                WHEN
-                    JSONB_TYPEOF(
-                        statements -> 'Action'
-                    ) = 'array' THEN statements -> 'Action'
-           END AS actions
-        FROM aws_s3_buckets,
-            JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
-        WHERE statements -> 'Effect' = '"Allow"' ) AS flatten_statements,
+    -- For each Statement return an array containing the prinicipals
+    CASE
+    WHEN
+    JSONB_TYPEOF(
+    statements -> 'Principal'
+    ) = 'string' THEN JSONB_BUILD_ARRAY(
+    statements -> 'Principal'
+    )
+    WHEN
+    JSONB_TYPEOF(
+    statements -> 'Principal' -> 'AWS'
+    ) = 'string' THEN JSONB_BUILD_ARRAY(
+    statements -> 'Principal' -> 'AWS'
+    )
+    WHEN
+    JSONB_TYPEOF(
+    statements -> 'Principal' -> 'AWS'
+    ) = 'array' THEN statements -> 'Principal' -> 'AWS'
+    END AS principals,
+    -- For each Statement return an array containing the Actions
+    CASE
+    WHEN
+    JSONB_TYPEOF(
+    statements -> 'Action'
+    ) = 'string' THEN JSONB_BUILD_ARRAY(statements -> 'Action')
+    WHEN
+    JSONB_TYPEOF(
+    statements -> 'Action'
+    ) = 'array' THEN statements -> 'Action'
+    END AS actions
+    FROM aws_s3_buckets,
+    JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
+    WHERE statements -> 'Effect' = '"Allow"') AS flatten_statements,
     JSONB_ARRAY_ELEMENTS(TO_JSONB(actions)) AS a,
     JSONB_ARRAY_ELEMENTS(TO_JSONB(principals)) AS p
 WHERE
-    -- Any cross account prinicipals (or unknown principals) get flagged
+-- Any cross account prinicipals (or unknown principals) get flagged
     (
-        p.value::TEXT NOT LIKE '"arn:aws:iam::' || account_id || ':%"' OR p.value::TEXT = '"*"'
+    p.value::TEXT NOT LIKE '"arn:aws:iam::' || account_id || ':%"'
+   OR p.value::TEXT = '"*"'
     )
-    -- Any broad permissions or Deletes get flagged
-    AND (a.value::TEXT LIKE '"s3:%*"' OR a.value::TEXT LIKE '"s3:DeleteObject"')
+-- Any broad permissions or Deletes get flagged
+  AND (a.value::TEXT LIKE '"s3:%*"'
+   OR a.value::TEXT LIKE '"s3:DeleteObject"')
 
 -- This will flag ALL canoninical IDs as NOT COMPLIANT
 -- This will flag ALL users that have been deleted as NOT COMPLIANT

--- a/queries/s3/restrict_cross_account_actions.sql
+++ b/queries/s3/restrict_cross_account_actions.sql
@@ -23,7 +23,7 @@ FROM
                     JSONB_TYPEOF(
                         statements -> 'Principal' -> 'AWS'
                     ) = 'array' THEN statements -> 'Principal' -> 'AWS'
-            END AS principals,
+           END AS principals,
             -- For each Statement return an array containing the Actions
             CASE
                 WHEN
@@ -34,7 +34,7 @@ FROM
                     JSONB_TYPEOF(
                         statements -> 'Action'
                     ) = 'array' THEN statements -> 'Action'
-            END AS actions
+           END AS actions
         FROM aws_s3_buckets,
             JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
         WHERE statements -> 'Effect' = '"Allow"' ) AS flatten_statements,

--- a/queries/s3/restrict_cross_account_actions.sql
+++ b/queries/s3/restrict_cross_account_actions.sql
@@ -2,52 +2,42 @@ SELECT arn,
        account_id,
        a.value::TEXT AS ACTION,
        p.value::TEXT AS USER --noqa
-FROM (SELECT aws_s3_buckets.arn,
-             account_id,
-             -- For each Statement return an array containing the prinicipals
-             CASE
-                 WHEN
-                         JSONB_TYPEOF(
-                                 statements -> 'Principal'
-                             ) = 'string' THEN JSONB_BUILD_ARRAY(
-                         statements -> 'Principal'
-                     )
-                 WHEN
-                         JSONB_TYPEOF(
-                                 statements -> 'Principal' -> 'AWS'
-                             ) = 'string' THEN JSONB_BUILD_ARRAY(
-                         statements -> 'Principal' -> 'AWS'
-                     )
-                 WHEN
-                         JSONB_TYPEOF(
-                                 statements -> 'Principal' -> 'AWS'
-                             ) = 'array' THEN statements -> 'Principal' -> 'AWS'
-                 END AS principals,
-             -- For each Statement return an array containing the Actions
-             CASE
-                 WHEN
-                         JSONB_TYPEOF(
-                                 statements -> 'Action'
-                             ) = 'string' THEN JSONB_BUILD_ARRAY(statements -> 'Action')
-                 WHEN
-                         JSONB_TYPEOF(
-                                 statements -> 'Action'
-                             ) = 'array' THEN statements -> 'Action'
-                 END AS actions
-      FROM aws_s3_buckets,
-           JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
-      WHERE statements -> 'Effect' = '"Allow"') AS flatten_statements,
-     JSONB_ARRAY_ELEMENTS(TO_JSONB(actions)) AS a,
-     JSONB_ARRAY_ELEMENTS(TO_JSONB(principals)) AS p
+FROM (
+    SELECT aws_s3_buckets.arn,
+        account_id,
+        -- For each Statement return an array containing the prinicipals
+        CASE
+            WHEN
+                JSONB_TYPEOF(statements -> 'Principal') = 'string' THEN
+                JSONB_BUILD_ARRAY( statements -> 'Principal')
+            WHEN
+                JSONB_TYPEOF(statements -> 'Principal' -> 'AWS') = 'string' THEN
+                JSONB_BUILD_ARRAY( statements -> 'Principal' -> 'AWS' )
+            WHEN
+                JSONB_TYPEOF(statements -> 'Principal' -> 'AWS') = 'array' THEN
+                statements -> 'Principal' -> 'AWS' END AS principals,
+        -- For each Statement return an array containing the Actions
+        CASE
+            WHEN
+                JSONB_TYPEOF(statements -> 'Action') = 'string' THEN
+                JSONB_BUILD_ARRAY(statements -> 'Action')
+            WHEN
+                JSONB_TYPEOF(statements -> 'Action') = 'array' THEN
+                statements -> 'Action' END AS actions
+    FROM aws_s3_buckets,
+        JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
+    WHERE statements -> 'Effect' = '"Allow"') AS flatten_statements,
+    JSONB_ARRAY_ELEMENTS(TO_JSONB(actions)) AS a,
+    JSONB_ARRAY_ELEMENTS(TO_JSONB(principals)) AS p
 WHERE
--- Any cross account prinicipals (or unknown principals) get flagged
+    -- Any cross account prinicipals (or unknown principals) get flagged
     (
-                p.value::TEXT NOT LIKE '"arn:aws:iam::' || account_id || ':%"'
-            OR p.value::TEXT = '"*"'
-        )
--- Any broad permissions or Deletes get flagged
-  AND (a.value::TEXT LIKE '"s3:%*"'
-    OR a.value::TEXT LIKE '"s3:DeleteObject"')
+        p.value::TEXT NOT LIKE '"arn:aws:iam::' || account_id || ':%"'
+        OR p.value::TEXT = '"*"'
+    )
+    -- Any broad permissions or Deletes get flagged
+    AND (a.value::TEXT LIKE '"s3:%*"'
+        OR a.value::TEXT LIKE '"s3:DeleteObject"')
 
 -- This will flag ALL canoninical IDs as NOT COMPLIANT
 -- This will flag ALL users that have been deleted as NOT COMPLIANT

--- a/queries/s3/restrict_cross_account_actions.sql
+++ b/queries/s3/restrict_cross_account_actions.sql
@@ -3,51 +3,51 @@ SELECT arn,
        a.value::TEXT AS ACTION,
        p.value::TEXT AS USER --noqa
 FROM (SELECT aws_s3_buckets.arn,
-    account_id,
-    -- For each Statement return an array containing the prinicipals
-    CASE
-    WHEN
-    JSONB_TYPEOF(
-    statements -> 'Principal'
-    ) = 'string' THEN JSONB_BUILD_ARRAY(
-    statements -> 'Principal'
-    )
-    WHEN
-    JSONB_TYPEOF(
-    statements -> 'Principal' -> 'AWS'
-    ) = 'string' THEN JSONB_BUILD_ARRAY(
-    statements -> 'Principal' -> 'AWS'
-    )
-    WHEN
-    JSONB_TYPEOF(
-    statements -> 'Principal' -> 'AWS'
-    ) = 'array' THEN statements -> 'Principal' -> 'AWS'
-    END AS principals,
-    -- For each Statement return an array containing the Actions
-    CASE
-    WHEN
-    JSONB_TYPEOF(
-    statements -> 'Action'
-    ) = 'string' THEN JSONB_BUILD_ARRAY(statements -> 'Action')
-    WHEN
-    JSONB_TYPEOF(
-    statements -> 'Action'
-    ) = 'array' THEN statements -> 'Action'
-    END AS actions
-    FROM aws_s3_buckets,
-    JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
-    WHERE statements -> 'Effect' = '"Allow"') AS flatten_statements,
-    JSONB_ARRAY_ELEMENTS(TO_JSONB(actions)) AS a,
-    JSONB_ARRAY_ELEMENTS(TO_JSONB(principals)) AS p
+             account_id,
+             -- For each Statement return an array containing the prinicipals
+             CASE
+                 WHEN
+                         JSONB_TYPEOF(
+                                 statements -> 'Principal'
+                             ) = 'string' THEN JSONB_BUILD_ARRAY(
+                         statements -> 'Principal'
+                     )
+                 WHEN
+                         JSONB_TYPEOF(
+                                 statements -> 'Principal' -> 'AWS'
+                             ) = 'string' THEN JSONB_BUILD_ARRAY(
+                         statements -> 'Principal' -> 'AWS'
+                     )
+                 WHEN
+                         JSONB_TYPEOF(
+                                 statements -> 'Principal' -> 'AWS'
+                             ) = 'array' THEN statements -> 'Principal' -> 'AWS'
+                 END AS principals,
+             -- For each Statement return an array containing the Actions
+             CASE
+                 WHEN
+                         JSONB_TYPEOF(
+                                 statements -> 'Action'
+                             ) = 'string' THEN JSONB_BUILD_ARRAY(statements -> 'Action')
+                 WHEN
+                         JSONB_TYPEOF(
+                                 statements -> 'Action'
+                             ) = 'array' THEN statements -> 'Action'
+                 END AS actions
+      FROM aws_s3_buckets,
+           JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
+      WHERE statements -> 'Effect' = '"Allow"') AS flatten_statements,
+     JSONB_ARRAY_ELEMENTS(TO_JSONB(actions)) AS a,
+     JSONB_ARRAY_ELEMENTS(TO_JSONB(principals)) AS p
 WHERE
 -- Any cross account prinicipals (or unknown principals) get flagged
     (
-    p.value::TEXT NOT LIKE '"arn:aws:iam::' || account_id || ':%"'
-   OR p.value::TEXT = '"*"'
-    )
+                p.value::TEXT NOT LIKE '"arn:aws:iam::' || account_id || ':%"'
+            OR p.value::TEXT = '"*"'
+        )
 -- Any broad permissions or Deletes get flagged
   AND (a.value::TEXT LIKE '"s3:%*"'
-   OR a.value::TEXT LIKE '"s3:DeleteObject"')
+    OR a.value::TEXT LIKE '"s3:DeleteObject"')
 
 -- This will flag ALL canoninical IDs as NOT COMPLIANT
 -- This will flag ALL users that have been deleted as NOT COMPLIANT

--- a/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
+++ b/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
@@ -3,7 +3,5 @@ SELECT account_id,
        arn,
        name
 FROM aws_secretsmanager_secrets
-WHERE last_accessed_date IS NULL
-    AND created_date > NOW() - INTERVAL '90 days'
-   OR last_accessed_date IS NOT NULL
-    AND last_accessed_date > NOW() - INTERVAL '90 days';
+WHERE (last_accessed_date IS NULL AND created_date > NOW() - INTERVAL '90 days')
+       OR (last_accessed_date IS NOT NULL AND last_accessed_date > NOW() - INTERVAL '90 days');

--- a/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
+++ b/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
@@ -1,8 +1,7 @@
-SELECT account_id,
+ELECT account_id,
        region,
        arn,
        name
 FROM aws_secretsmanager_secrets
 WHERE last_accessed_date IS NULL AND created_date > now() - INTERVAL '90 days'
-      OR last_accessed_date IS NOT NULL AND last_accessed_date > now() - INTERVAL '90 days'
-;
+     OR last_accessed_date IS NOT NULL AND last_accessed_date > now() - INTERVAL '90 days';

--- a/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
+++ b/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
@@ -6,5 +6,4 @@ FROM aws_secretsmanager_secrets
 WHERE last_accessed_date IS NULL
     AND created_date > NOW() - INTERVAL '90 days'
    OR last_accessed_date IS NOT NULL
-    AND last_accessed_date
-          > NOW() - INTERVAL '90 days';
+    AND last_accessed_date > NOW() - INTERVAL '90 days';

--- a/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
+++ b/queries/secretsmanager/remove_unused_secrets_manager_secrets.sql
@@ -1,7 +1,10 @@
-ELECT account_id,
+SELECT account_id,
        region,
        arn,
        name
 FROM aws_secretsmanager_secrets
-WHERE last_accessed_date IS NULL AND created_date > now() - INTERVAL '90 days'
-     OR last_accessed_date IS NOT NULL AND last_accessed_date > now() - INTERVAL '90 days';
+WHERE last_accessed_date IS NULL
+    AND created_date > NOW() - INTERVAL '90 days'
+   OR last_accessed_date IS NOT NULL
+    AND last_accessed_date
+          > NOW() - INTERVAL '90 days';

--- a/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
+++ b/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
@@ -3,7 +3,5 @@ SELECT account_id,
        arn,
        name
 FROM aws_secretsmanager_secrets
-WHERE last_rotated_date IS NULL
-    AND created_date > NOW() - INTERVAL '90 days'
-   OR last_rotated_date IS NOT NULL
-    AND last_rotated_date > NOW() - INTERVAL '90 days';
+WHERE (last_rotated_date IS NULL AND created_date > NOW() - INTERVAL '90 days')
+       OR (last_rotated_date IS NOT NULL AND last_rotated_date > NOW() - INTERVAL '90 days');

--- a/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
+++ b/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
@@ -3,5 +3,8 @@ SELECT account_id,
        arn,
        name
 FROM aws_secretsmanager_secrets
-WHERE last_rotated_date IS NULL AND created_date > now() - INTERVAL '90 days'
-     OR last_rotated_date IS NOT NULL AND last_rotated_date > now() - INTERVAL '90 days';
+WHERE last_rotated_date IS NULL
+    AND created_date > NOW() - INTERVAL '90 days'
+   OR last_rotated_date IS NOT NULL
+    AND last_rotated_date
+          > NOW() - INTERVAL '90 days';

--- a/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
+++ b/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
@@ -6,5 +6,4 @@ FROM aws_secretsmanager_secrets
 WHERE last_rotated_date IS NULL
     AND created_date > NOW() - INTERVAL '90 days'
    OR last_rotated_date IS NOT NULL
-    AND last_rotated_date
-          > NOW() - INTERVAL '90 days';
+    AND last_rotated_date > NOW() - INTERVAL '90 days';

--- a/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
+++ b/queries/secretsmanager/secrets_should_be_rotated_within_a_specified_number_of_days.sql
@@ -4,5 +4,4 @@ SELECT account_id,
        name
 FROM aws_secretsmanager_secrets
 WHERE last_rotated_date IS NULL AND created_date > now() - INTERVAL '90 days'
-      OR last_rotated_date IS NOT NULL AND last_rotated_date > now() - INTERVAL '90 days'
-;
+     OR last_rotated_date IS NOT NULL AND last_rotated_date > now() - INTERVAL '90 days';


### PR DESCRIPTION
- since cq-provider-aws v0.10.0 there will be no db_cluster_arn column in aws_rds_clusters table some queries are changed
- new linter rules are taken into account