### PR TITLE
fix: KMS.2 Control

### DIFF
--- a/queries/kms/inline_policy_blocked_kms_actions.sql
+++ b/queries/kms/inline_policy_blocked_kms_actions.sql
@@ -49,7 +49,7 @@ WHERE
         'arn:aws:kms:*:' || account_id || ':key/*'
         'arn:aws:kms:*:*:alias/*',
         'arn:aws:kms:*:' || account_id || ':alias/*'
-	] --noqa
+	]
 
     AND LOWER(statement::TEXT)::JSONB -> 'action' ?| ARRAY[
         '*',

--- a/queries/kms/inline_policy_blocked_kms_actions.sql
+++ b/queries/kms/inline_policy_blocked_kms_actions.sql
@@ -1,60 +1,60 @@
 SELECT arn,
        account_id
 FROM
-	(   
+    (
         -- select all user policies
         SELECT statement,
-			aws_iam_users.account_id,
-			arn,
-			aws_iam_users.cq_id
-		FROM aws_iam_user_policies
-		CROSS JOIN LATERAL jsonb_array_elements(
-            CASE JSONB_TYPEOF(policy_document -> 'Statement')
-                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
-                WHEN 'array' THEN policy_document -> 'Statement' END
-        ) as statement
-		JOIN aws_iam_users ON aws_iam_users.cq_id = aws_iam_user_policies.user_cq_id
-		UNION 
+            aws_iam_users.account_id,
+            arn,
+            aws_iam_users.cq_id
+        FROM aws_iam_user_policies
+            CROSS JOIN LATERAL jsonb_array_elements(
+                CASE JSONB_TYPEOF(policy_document -> 'Statement')
+                    WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
+                    WHEN 'array' THEN policy_document -> 'Statement' END
+                ) AS statement
+            JOIN aws_iam_users ON aws_iam_users.cq_id = aws_iam_user_policies.user_cq_id
+        UNION
         -- select all role policies
         SELECT statement,
-			aws_iam_roles.account_id,
-			arn,
-			aws_iam_roles.cq_id
-		FROM aws_iam_role_policies
-	 	CROSS JOIN LATERAL jsonb_array_elements(
-            CASE JSONB_TYPEOF(policy_document -> 'Statement')
-                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
-                WHEN 'array' THEN policy_document -> 'Statement' END
-        ) as statement
-		JOIN aws_iam_roles ON aws_iam_roles.cq_id = aws_iam_role_policies.role_cq_id
-		WHERE LOWER(arn) NOT LIKE 'arn:aws:iam::%:role/aws-service-role/%'
-		UNION 
+            aws_iam_roles.account_id,
+            arn,
+            aws_iam_roles.cq_id
+        FROM aws_iam_role_policies
+             CROSS JOIN LATERAL jsonb_array_elements(
+                CASE JSONB_TYPEOF(policy_document -> 'Statement')
+                    WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
+                    WHEN 'array' THEN policy_document -> 'Statement' END
+             ) AS statement
+            JOIN aws_iam_roles ON aws_iam_roles.cq_id = aws_iam_role_policies.role_cq_id
+        WHERE LOWER(arn) NOT LIKE 'arn:aws:iam::%:role/aws-service-role/%'
+        UNION
         -- select all group policies
         SELECT statement,
-			aws_iam_groups.account_id,
-			arn,
-			aws_iam_groups.cq_id
-		FROM aws_iam_group_policies
-	 	CROSS JOIN LATERAL jsonb_array_elements(
-            CASE JSONB_TYPEOF(policy_document -> 'Statement')
-                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
-                WHEN 'array' THEN policy_document -> 'Statement' END
-        ) as statement
-		JOIN aws_iam_groups ON aws_iam_groups.cq_id = aws_iam_group_policies.group_cq_id) T
-WHERE 
-	statement ->> 'Effect' = 'Allow'
-	AND LOWER(statement::text)::JSONB -> 'resource' ?| array[
-		'*',
-		'arn:aws:kms:*:*:key/*',
-		'arn:aws:kms:*:' || account_id || ':key/*'
-		'arn:aws:kms:*:*:alias/*',
-		'arn:aws:kms:*:' || account_id || ':alias/*'
+            aws_iam_groups.account_id,
+            arn,
+            aws_iam_groups.cq_id
+        FROM aws_iam_group_policies
+            CROSS JOIN LATERAL jsonb_array_elements(
+                CASE JSONB_TYPEOF(policy_document -> 'Statement')
+                    WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
+                    WHEN 'array' THEN policy_document -> 'Statement' END
+                ) AS statement
+            JOIN aws_iam_groups ON aws_iam_groups.cq_id = aws_iam_group_policies.group_cq_id) T
+WHERE
+    statement ->> 'Effect' = 'Allow'
+    AND LOWER(statement::TEXT)::JSONB -> 'resource' ?| ARRAY[
+        '*',
+        'arn:aws:kms:*:*:key/*',
+        'arn:aws:kms:*:' || account_id || ':key/*'
+        'arn:aws:kms:*:*:alias/*',
+        'arn:aws:kms:*:' || account_id || ':alias/*'
 	] --noqa
 
-	AND LOWER(statement::text)::JSONB -> 'action' ?| array[
-		'*',
-		'kms:*',
-		'kms:decrypt',
-		'kms:encrypt*',
-		'kms:reencryptfrom'
-	]
+    AND LOWER(statement::TEXT)::JSONB -> 'action' ?| ARRAY[
+        '*',
+        'kms:*',
+        'kms:decrypt',
+        'kms:encrypt*',
+        'kms:reencryptfrom'
+    ]

--- a/queries/kms/inline_policy_blocked_kms_actions.sql
+++ b/queries/kms/inline_policy_blocked_kms_actions.sql
@@ -1,29 +1,33 @@
 SELECT arn,
        account_id
 FROM
-	(SELECT statement,
+	(   
+        -- select all user policies
+        SELECT statement,
 			aws_iam_users.account_id,
 			arn,
 			aws_iam_users.cq_id
 		FROM aws_iam_user_policies
-		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_user_policies.policy_document -> 'Statement') as STATEMENT
+		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_user_policies.policy_document -> 'Statement') as statement
 		JOIN aws_iam_users ON aws_iam_users.cq_id = aws_iam_user_policies.user_cq_id
 		UNION 
+        -- select all role policies
         SELECT statement,
 			aws_iam_roles.account_id,
 			arn,
 			aws_iam_roles.cq_id
 		FROM aws_iam_role_policies
-	 		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_role_policies.policy_document -> 'Statement') as STATEMENT
+	 		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_role_policies.policy_document -> 'Statement') as statement
 		JOIN aws_iam_roles ON aws_iam_roles.cq_id = aws_iam_role_policies.role_cq_id
 		WHERE LOWER(arn) NOT LIKE 'arn:aws:iam::%:role/aws-service-role/%'
 		UNION 
+        -- select all group policies
         SELECT statement,
 			aws_iam_groups.account_id,
 			arn,
 			aws_iam_groups.cq_id
 		FROM aws_iam_group_policies
-	 	 		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_group_policies.policy_document -> 'Statement') as STATEMENT
+	 	 		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_group_policies.policy_document -> 'Statement') as statement
 		JOIN aws_iam_groups ON aws_iam_groups.cq_id = aws_iam_group_policies.group_cq_id) T
 WHERE 
 	statement ->> 'Effect' = 'Allow'

--- a/queries/kms/inline_policy_blocked_kms_actions.sql
+++ b/queries/kms/inline_policy_blocked_kms_actions.sql
@@ -25,7 +25,7 @@ FROM
                 CASE JSONB_TYPEOF(policy_document -> 'Statement')
                     WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
                     WHEN 'array' THEN policy_document -> 'Statement' END
-             ) AS statement
+                ) AS statement
             JOIN aws_iam_roles ON aws_iam_roles.cq_id = aws_iam_role_policies.role_cq_id
         WHERE LOWER(arn) NOT LIKE 'arn:aws:iam::%:role/aws-service-role/%'
         UNION
@@ -49,7 +49,7 @@ WHERE
         'arn:aws:kms:*:' || account_id || ':key/*'
         'arn:aws:kms:*:*:alias/*',
         'arn:aws:kms:*:' || account_id || ':alias/*'
-	]
+    ]
 
     AND LOWER(statement::TEXT)::JSONB -> 'action' ?| ARRAY[
         '*',

--- a/queries/kms/inline_policy_blocked_kms_actions.sql
+++ b/queries/kms/inline_policy_blocked_kms_actions.sql
@@ -1,66 +1,44 @@
-WITH iam_users AS (
-    SELECT policy_document,
-        aws_iam_users.account_id,
-        arn,
-        aws_iam_users.cq_id
-    FROM aws_iam_user_policies
-        JOIN aws_iam_users ON aws_iam_users.cq_id = aws_iam_user_policies.user_cq_id
-),
-iam_user_violations AS (
-    SELECT DISTINCT cq_id
-    FROM iam_users,
-        jsonb_array_elements(policy_document -> 'Statement') AS statement
-    WHERE
-        statement ->> 'Effect' = 'Allow'
-        AND statement -> 'Resource' ?| array['*', 'arn:aws:kms:*:' || account_id || ':key/*', 'arn:aws:kms:*:' || account_id || ':alias/*'] --noqa
-        AND statement -> 'Action' ?| array['*', 'kms:*', 'kms:decrypt', 'kms:deencrypt*', 'kms:reencryptfrom']
-),
-iam_roles AS (
-    SELECT policy_document,
-        aws_iam_roles.account_id,
-        arn,
-        aws_iam_roles.cq_id
-    FROM aws_iam_role_policies
-        JOIN aws_iam_roles ON aws_iam_roles.cq_id = aws_iam_role_policies.role_cq_id
-),
-iam_role_violations AS (
-    SELECT DISTINCT cq_id
-    FROM iam_roles,
-        jsonb_array_elements(policy_document -> 'Statement') AS statement
-    WHERE
-        statement ->> 'Effect' = 'Allow'
-        AND statement -> 'Resource' ?| array['*', 'arn:aws:kms:*:' || account_id || ':key/*', 'arn:aws:kms:*:' || account_id || ':alias/*'] --noqa
-        AND statement -> 'Action' ?| array['*', 'kms:*', 'kms:decrypt', 'kms:deencrypt*', 'kms:reencryptfrom']
-),
-iam_groups AS (
-    SELECT policy_document,
-        aws_iam_groups.account_id,
-        arn,
-        aws_iam_groups.cq_id
-    FROM aws_iam_group_policies
-        JOIN aws_iam_groups ON aws_iam_groups.cq_id = aws_iam_group_policies.group_cq_id
-),
-iam_group_violations AS (
-    SELECT DISTINCT cq_id
-    FROM iam_groups,
-        jsonb_array_elements(policy_document -> 'Statement') AS statement
-    WHERE
-        statement ->> 'Effect' = 'Allow'
-        AND statement -> 'Resource' ?| array['*', 'arn:aws:kms:*:' || account_id || ':key/*', 'arn:aws:kms:*:' || account_id || ':alias/*'] --noqa
-        AND statement -> 'Action' ?| array['*', 'kms:*', 'kms:decrypt', 'kms:deencrypt*', 'kms:reencryptfrom']
-)
 SELECT arn,
        account_id
-FROM aws_iam_users
-     JOIN iam_user_violations ON iam_user_violations.cq_id = aws_iam_users.cq_id
-UNION
-SELECT arn,
-       account_id
-FROM aws_iam_roles
-     JOIN iam_role_violations ON iam_role_violations.cq_id = aws_iam_roles.cq_id
-WHERE arn NOT LIKE 'arn:aws:iam::%:role/aws-service-role/%'
-UNION
-SELECT arn,
-       account_id
-FROM aws_iam_groups
-     JOIN iam_group_violations ON iam_group_violations.cq_id = aws_iam_groups.cq_id;
+FROM
+	(SELECT statement,
+			aws_iam_users.account_id,
+			arn,
+			aws_iam_users.cq_id
+		FROM aws_iam_user_policies
+		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_user_policies.policy_document -> 'Statement') as STATEMENT
+		JOIN aws_iam_users ON aws_iam_users.cq_id = aws_iam_user_policies.user_cq_id
+		UNION 
+        SELECT statement,
+			aws_iam_roles.account_id,
+			arn,
+			aws_iam_roles.cq_id
+		FROM aws_iam_role_policies
+	 		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_role_policies.policy_document -> 'Statement') as STATEMENT
+		JOIN aws_iam_roles ON aws_iam_roles.cq_id = aws_iam_role_policies.role_cq_id
+		WHERE LOWER(arn) NOT LIKE 'arn:aws:iam::%:role/aws-service-role/%'
+		UNION 
+        SELECT statement,
+			aws_iam_groups.account_id,
+			arn,
+			aws_iam_groups.cq_id
+		FROM aws_iam_group_policies
+	 	 		 CROSS JOIN LATERAL jsonb_array_elements(aws_iam_group_policies.policy_document -> 'Statement') as STATEMENT
+		JOIN aws_iam_groups ON aws_iam_groups.cq_id = aws_iam_group_policies.group_cq_id) T
+WHERE 
+	statement ->> 'Effect' = 'Allow'
+	AND LOWER(statement::text)::JSONB -> 'resource' ?| array[
+		'*',
+		'arn:aws:kms:*:*:key/*',
+		'arn:aws:kms:*:' || account_id || ':key/*'
+		'arn:aws:kms:*:*:alias/*',
+		'arn:aws:kms:*:' || account_id || ':alias/*'
+	] --noqa
+
+	AND LOWER(statement::text)::JSONB -> 'action' ?| array[
+		'*',
+		'kms:*',
+		'kms:decrypt',
+		'kms:encrypt*',
+		'kms:reencryptfrom'
+	]

--- a/test/policy_cq_config.hcl
+++ b/test/policy_cq_config.hcl
@@ -2,7 +2,7 @@
 cloudquery {
 
   provider "aws" {
-    source  = "cloudquery/cq-provider-aws"
+    source  = "cloudquery/aws"
     version = "latest"
   }
 


### PR DESCRIPTION

fixes:
- `Statement` in IAM policy can be a singular object rather than an array
- Catch `*` in region
- Ensure case matches
- fix action name