### PR TITLE
fix: Handle Singular IAM Statement in Policy

### DIFF
--- a/queries/iam/no_star.sql
+++ b/queries/iam/no_star.sql
@@ -3,9 +3,9 @@ WITH violations AS (
            COUNT(*) AS violations
     FROM aws_iam_policy_versions,
         JSONB_ARRAY_ELEMENTS(
-            CASE JSONB_TYPEOF(policy_document -> 'Statement')
-                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
-                WHEN 'array' THEN policy_document -> 'Statement'
+            CASE JSONB_TYPEOF(document -> 'Statement')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(document ->> 'Statement')
+                WHEN 'array' THEN document -> 'Statement'
             END
         ) AS statement,
         JSONB_ARRAY_ELEMENTS_TEXT(

--- a/queries/iam/no_star.sql
+++ b/queries/iam/no_star.sql
@@ -2,7 +2,12 @@ WITH violations AS (
     SELECT policy_cq_id,
            COUNT(*) AS violations
     FROM aws_iam_policy_versions,
-        JSONB_ARRAY_ELEMENTS(document -> 'Statement') AS statement,
+        JSONB_ARRAY_ELEMENTS(
+            CASE JSONB_TYPEOF(policy_document -> 'Statement')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
+                WHEN 'array' THEN policy_document -> 'Statement'
+            END
+        ) AS statement,
         JSONB_ARRAY_ELEMENTS_TEXT(
             CASE JSONB_TYPEOF(statement -> 'Resource')
                 WHEN 'string' THEN JSONB_BUILD_ARRAY(statement ->> 'Resource')

--- a/queries/iam/policies_with_admin_rights.sql
+++ b/queries/iam/policies_with_admin_rights.sql
@@ -4,7 +4,7 @@ WITH policy_statements AS (
         JSONB_ARRAY_ELEMENTS(
             CASE JSONB_TYPEOF(v.document -> 'Statement')
                 WHEN 'string' THEN JSONB_BUILD_ARRAY(v.document ->> 'Statement')
-                WHEN 'array' THEN v.document -> 'Statement' END    
+                WHEN 'array' THEN v.document -> 'Statement' END
         ) AS statement
     FROM
         aws_iam_policies p

--- a/queries/iam/policies_with_admin_rights.sql
+++ b/queries/iam/policies_with_admin_rights.sql
@@ -1,7 +1,11 @@
 WITH policy_statements AS (
     SELECT
         p.cq_id AS cq_id,
-        JSONB_ARRAY_ELEMENTS(v.document -> 'Statement') AS statement
+        JSONB_ARRAY_ELEMENTS(
+            CASE JSONB_TYPEOF(v.document -> 'Statement')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(v.document ->> 'Statement')
+                WHEN 'array' THEN v.document -> 'Statement' END    
+        ) AS statement
     FROM
         aws_iam_policies p
         LEFT JOIN aws_iam_policy_versions v

--- a/queries/iam/wildcard_access_policies.sql
+++ b/queries/iam/wildcard_access_policies.sql
@@ -1,7 +1,12 @@
 WITH policy_statements AS (
     SELECT
         p.cq_id AS cq_id,
-        JSONB_ARRAY_ELEMENTS(v.document -> 'Statement') AS statement
+        JSONB_ARRAY_ELEMENTS(
+            CASE JSONB_TYPEOF(v.document -> 'Statement')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(v.document ->> 'Statement')
+                WHEN 'array' THEN v.document -> 'Statement'
+            END
+        ) AS statement,
     FROM
         aws_iam_policies p
         LEFT JOIN aws_iam_policy_versions v

--- a/queries/iam/wildcard_access_policies.sql
+++ b/queries/iam/wildcard_access_policies.sql
@@ -6,7 +6,7 @@ WITH policy_statements AS (
                 WHEN 'string' THEN JSONB_BUILD_ARRAY(v.document ->> 'Statement')
                 WHEN 'array' THEN v.document -> 'Statement'
             END
-        ) AS statement,
+        ) AS statement
     FROM
         aws_iam_policies p
         LEFT JOIN aws_iam_policy_versions v

--- a/queries/lambda/lambda_function_prohibit_public_access.sql
+++ b/queries/lambda/lambda_function_prohibit_public_access.sql
@@ -3,11 +3,11 @@ SELECT account_id,
        arn
 FROM aws_lambda_functions,
     jsonb_array_elements(
-            CASE JSONB_TYPEOF(policy_document -> 'Statement')
-                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
-                WHEN 'array' THEN policy_document -> 'Statement'
-            END
-        ) AS statement
+        CASE JSONB_TYPEOF(policy_document -> 'Statement')
+            WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
+            WHEN 'array' THEN policy_document -> 'Statement'
+        END
+    ) AS statement
 WHERE statment ->> 'Effect' = 'Allow'
     AND (
         statment ->> 'Principal' = '*'

--- a/queries/lambda/lambda_function_prohibit_public_access.sql
+++ b/queries/lambda/lambda_function_prohibit_public_access.sql
@@ -2,7 +2,12 @@ SELECT account_id,
        region,
        arn
 FROM aws_lambda_functions,
-    jsonb_array_elements(policy_document -> 'Statement') AS statment
+    jsonb_array_elements(
+            CASE JSONB_TYPEOF(policy_document -> 'Statement')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy_document ->> 'Statement')
+                WHEN 'array' THEN policy_document -> 'Statement'
+            END
+        ) AS statement
 WHERE statment ->> 'Effect' = 'Allow'
     AND (
         statment ->> 'Principal' = '*'

--- a/queries/lambda/lambda_function_prohibit_public_access.sql
+++ b/queries/lambda/lambda_function_prohibit_public_access.sql
@@ -8,9 +8,9 @@ FROM aws_lambda_functions,
             WHEN 'array' THEN policy_document -> 'Statement'
         END
     ) AS statement
-WHERE statment ->> 'Effect' = 'Allow'
+WHERE statement ->> 'Effect' = 'Allow'
     AND (
-        statment ->> 'Principal' = '*'
-        OR statment -> 'Principal' ->> 'AWS' = '*'
-        OR (statment -> 'Principal' ->> 'AWS')::JSONB ? '*'
+        statement ->> 'Principal' = '*'
+        OR statement -> 'Principal' ->> 'AWS' = '*'
+        OR (statement -> 'Principal' ->> 'AWS')::JSONB ? '*'
     );

--- a/queries/s3/deny_http_requests.sql
+++ b/queries/s3/deny_http_requests.sql
@@ -15,7 +15,12 @@ WHERE
                     statements
                 FROM
                     aws_s3_buckets,
-                    jsonb_array_elements(policy -> 'Statement') AS statements
+                    jsonb_array_elements(
+                        CASE JSONB_TYPEOF(policy -> 'Statement')
+                            WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
+                            WHEN 'array' THEN policy -> 'Statement'
+                        END
+                    ) AS statements 
                 WHERE
                     statements -> 'Effect' = '"Deny"'
             ) AS foo,

--- a/queries/s3/deny_http_requests.sql
+++ b/queries/s3/deny_http_requests.sql
@@ -20,7 +20,7 @@ WHERE
                             WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
                             WHEN 'array' THEN policy -> 'Statement'
                         END
-                    ) AS statements 
+                    ) AS statements
                 WHERE
                     statements -> 'Effect' = '"Deny"'
             ) AS foo,

--- a/queries/s3/publicly_readable_buckets.sql
+++ b/queries/s3/publicly_readable_buckets.sql
@@ -22,7 +22,12 @@ FROM
                     statements -> 'Principal' AS principals
                 FROM
                     aws_s3_buckets,
-                    jsonb_array_elements(policy -> 'Statement') AS statements
+                    jsonb_array_elements(
+                        CASE JSONB_TYPEOF(policy -> 'Statement')
+                            WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
+                            WHEN 'array' THEN policy -> 'Statement'
+                        END
+                    ) AS statements 
                 WHERE
                     statements -> 'Effect' = '"Allow"'
             ) AS foo

--- a/queries/s3/publicly_readable_buckets.sql
+++ b/queries/s3/publicly_readable_buckets.sql
@@ -27,7 +27,7 @@ FROM
                             WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
                             WHEN 'array' THEN policy -> 'Statement'
                         END
-                    ) AS statements 
+                    ) AS statements
                 WHERE
                     statements -> 'Effect' = '"Allow"'
             ) AS foo

--- a/queries/s3/publicly_writable_buckets.sql
+++ b/queries/s3/publicly_writable_buckets.sql
@@ -22,7 +22,12 @@ FROM
                     statements -> 'Principal' AS principals
                 FROM
                     aws_s3_buckets,
-                    jsonb_array_elements(policy -> 'Statement') AS statements
+                    jsonb_array_elements(
+                        CASE JSONB_TYPEOF(policy -> 'Statement')
+                            WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
+                            WHEN 'array' THEN policy -> 'Statement'
+                        END
+                    ) AS statements 
                 WHERE
                     statements -> 'Effect' = '"Allow"'
             ) AS foo

--- a/queries/s3/publicly_writable_buckets.sql
+++ b/queries/s3/publicly_writable_buckets.sql
@@ -27,7 +27,7 @@ FROM
                             WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
                             WHEN 'array' THEN policy -> 'Statement'
                         END
-                    ) AS statements 
+                    ) AS statements
                 WHERE
                     statements -> 'Effect' = '"Allow"'
             ) AS foo

--- a/queries/s3/restrict_cross_account_actions.sql
+++ b/queries/s3/restrict_cross_account_actions.sql
@@ -25,7 +25,12 @@ FROM (
                 JSONB_TYPEOF(statements -> 'Action') = 'array' THEN
                 statements -> 'Action' END AS actions
     FROM aws_s3_buckets,
-        JSONB_ARRAY_ELEMENTS(policy -> 'Statement') AS statements
+        jsonb_array_elements(
+            CASE JSONB_TYPEOF(policy -> 'Statement')
+                WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
+                WHEN 'array' THEN policy -> 'Statement'
+            END
+        ) AS statements 
     WHERE statements -> 'Effect' = '"Allow"') AS flatten_statements,
     JSONB_ARRAY_ELEMENTS(TO_JSONB(actions)) AS a,
     JSONB_ARRAY_ELEMENTS(TO_JSONB(principals)) AS p

--- a/queries/s3/restrict_cross_account_actions.sql
+++ b/queries/s3/restrict_cross_account_actions.sql
@@ -30,7 +30,7 @@ FROM (
                 WHEN 'string' THEN JSONB_BUILD_ARRAY(policy ->> 'Statement')
                 WHEN 'array' THEN policy -> 'Statement'
             END
-        ) AS statements 
+        ) AS statements
     WHERE statements -> 'Effect' = '"Allow"') AS flatten_statements,
     JSONB_ARRAY_ELEMENTS(TO_JSONB(actions)) AS a,
     JSONB_ARRAY_ELEMENTS(TO_JSONB(principals)) AS p


### PR DESCRIPTION
Identified more instances where we assumed Statements is an array 