### PR TITLE
fix: Remove CIS control name from title

### DIFF
--- a/cis_v1.2.0/section_1.hcl
+++ b/cis_v1.2.0/section_1.hcl
@@ -57,37 +57,37 @@ policy "1" {
   }
 
   check "1.10" {
-    title = "1.10 Ensure IAM password policy prevents password reuse"
+    title = "Ensure IAM password policy prevents password reuse"
     doc   = file("cis_v1.2.0/docs/1.10.md")
     query = file("queries/iam/password_policy_prevent_reuse.sql")
   }
 
   check "1.11" {
-    title = "1.11 Ensure IAM password policy expires passwords within 90 days or less"
+    title = "Ensure IAM password policy expires passwords within 90 days or less"
     doc   = file("cis_v1.2.0/docs/1.11.md")
     query = file("queries/iam/password_policy_prevent_reuse.sql")
   }
 
   check "1.12" {
-    title = "1.12  Ensure no root account access key exists (Scored)"
+    title = " Ensure no root account access key exists (Scored)"
     doc   = file("cis_v1.2.0/docs/1.12.md")
     query = file("queries/iam/root_user_no_access_keys.sql")
   }
 
   check "1.13" {
-    title = "1.13 Ensure MFA is enabled for the 'root' account"
+    title = "Ensure MFA is enabled for the 'root' account"
     doc   = file("cis_v1.2.0/docs/1.13.md")
     query = file("queries/iam/mfa_enabled_for_root.sql")
   }
 
   check "1.14" {
-    title = "1.14 Ensure hardware MFA is enabled for the 'root' account (Scored)"
+    title = "Ensure hardware MFA is enabled for the 'root' account (Scored)"
     doc   = file("cis_v1.2.0/docs/1.14.md")
     query = file("queries/iam/hardware_mfa_enabled_for_root.sql")
   }
 
   check "1.16" {
-    title = "1.16 Ensure IAM policies are attached only to groups or roles (Scored)"
+    title = "Ensure IAM policies are attached only to groups or roles (Scored)"
     doc   = file("cis_v1.2.0/docs/1.16.md")
     query = file("queries/iam/policies_attached_to_groups_roles.sql")
   }

--- a/cis_v1.2.0/section_1.hcl
+++ b/cis_v1.2.0/section_1.hcl
@@ -3,55 +3,55 @@ policy "1" {
   doc   = file("cis_v1.2.0/docs/1.md")
 
   check "1.1" {
-    title = "1.1 Avoid the use of 'root' account. Show used in last 30 days (Scored)"
+    title = "Avoid the use of 'root' account. Show used in last 30 days (Scored)"
     doc   = file("cis_v1.2.0/docs/1.1.md")
     query = file("queries/iam/avoid_root_usage.sql")
   }
 
   check "1.2" {
-    title = "1.2 Ensure MFA is enabled for all IAM users that have a console password (Scored)"
+    title = "Ensure MFA is enabled for all IAM users that have a console password (Scored)"
     doc   = file("cis_v1.2.0/docs/1.2.md")
     query = file("queries/iam/mfa_enabled_for_console_access.sql")
   }
 
   check "1.3" {
-    title = "1.3 Ensure credentials unused for 90 days or greater are disabled (Scored)"
+    title = "Ensure credentials unused for 90 days or greater are disabled (Scored)"
     doc   = file("cis_v1.2.0/docs/1.3.md")
     query = file("queries/iam/unused_creds_disabled.sql")
   }
 
   check "1.4" {
-    title = "1.4 Ensure access keys are rotated every 90 days or less"
+    title = "Ensure access keys are rotated every 90 days or less"
     doc   = file("cis_v1.2.0/docs/1.4.md")
     query = file("queries/iam/old_access_keys.sql")
   }
 
   check "1.5" {
-    title = "1.5  Ensure IAM password policy requires at least one uppercase letter"
+    title = " Ensure IAM password policy requires at least one uppercase letter"
     doc   = file("cis_v1.2.0/docs/1.5.md")
     query = file("queries/iam/password_policy_min_uppercase.sql")
   }
 
   check "1.6" {
-    title = "1.6  Ensure IAM password policy requires at least one lowercase letter"
+    title = " Ensure IAM password policy requires at least one lowercase letter"
     doc   = file("cis_v1.2.0/docs/1.6.md")
     query = file("queries/iam/password_policy_min_lowercase.sql")
   }
 
   check "1.7" {
-    title = "1.7  Ensure IAM password policy requires at least one symbol"
+    title = " Ensure IAM password policy requires at least one symbol"
     doc   = file("cis_v1.2.0/docs/1.7.md")
     query = file("queries/iam/password_policy_min_one_symbol.sql")
   }
 
   check "1.8" {
-    title = "1.8  Ensure IAM password policy requires at least one number"
+    title = " Ensure IAM password policy requires at least one number"
     doc   = file("cis_v1.2.0/docs/1.8.md")
     query = file("queries/iam/password_policy_min_number.sql")
   }
 
   check "1.9" {
-    title = "1.9 Ensure IAM password policy requires minimum length of 14 or greater"
+    title = "Ensure IAM password policy requires minimum length of 14 or greater"
     doc   = file("cis_v1.2.0/docs/1.9.md")
     query = file("queries/iam/password_policy_min_length.sql")
   }

--- a/cis_v1.2.0/section_2.hcl
+++ b/cis_v1.2.0/section_2.hcl
@@ -3,43 +3,43 @@ policy "2" {
   doc   = file("cis_v1.2.0/docs/2.md")
 
   check "2.1" {
-    title = "2.1 Ensure CloudTrail is enabled in all regions"
+    title = "Ensure CloudTrail is enabled in all regions"
     doc   = file("cis_v1.2.0/docs/2.1.md")
     query = file("queries/cloudtrail/enabled_in_all_regions.sql")
   }
 
   check "2.2" {
-    title = "2.2 Ensure CloudTrail log file validation is enabled"
+    title = "Ensure CloudTrail log file validation is enabled"
     doc   = file("cis_v1.2.0/docs/2.2.md")
     query = file("queries/cloudtrail/log_file_validation_enabled.sql")
   }
 
   check "2.4" {
-    title = "2.4 Ensure CloudTrail trails are integrated with CloudWatch Logs"
+    title = "Ensure CloudTrail trails are integrated with CloudWatch Logs"
     doc   = file("cis_v1.2.0/docs/2.4.md")
     query = file("queries/cloudtrail/integrated_with_cloudwatch_logs.sql")
   }
 
   check "2.6" {
-    title = "2.6 Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket"
+    title = "Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket"
     doc   = file("cis_v1.2.0/docs/2.6.md")
     query = file("queries/cloudtrail/bucket_access_logging.sql")
   }
 
   check "2.7" {
-    title = "2.7 Ensure CloudTrail logs are encrypted at rest using KMS CMKs"
+    title = "Ensure CloudTrail logs are encrypted at rest using KMS CMKs"
     doc   = file("cis_v1.2.0/docs/2.7.md")
     query = file("queries/cloudtrail/logs_encrypted.sql")
   }
 
   check "2.8" {
-    title = "2.8 Ensure rotation for customer created CMKs is enabled (Scored)"
+    title = "Ensure rotation for customer created CMKs is enabled (Scored)"
     doc   = file("cis_v1.2.0/docs/2.8.md")
     query = file("queries/kms/rotation_enabled_for_customer_key.sql")
   }
 
   check "2.9" {
-    title = "2.9 Ensure VPC flow logging is enabled in all VPCs (Scored)"
+    title = "Ensure VPC flow logging is enabled in all VPCs (Scored)"
     doc   = file("cis_v1.2.0/docs/2.9.md")
     query = file("queries/ec2/flow_logs_enabled_in_all_vpcs.sql")
   }

--- a/cis_v1.2.0/section_3.hcl
+++ b/cis_v1.2.0/section_3.hcl
@@ -66,35 +66,35 @@ policy "3" {
   }
 
   check "3.10" {
-    title         = "3.10 Ensure a log metric filter and alarm exist for security group changes (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for security group changes (Scored)"
     doc           = file("cis_v1.2.0/docs/3.10.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_security_group_changes.sql")
   }
 
   check "3.11" {
-    title         = "3.11 Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL) (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL) (Scored)"
     doc           = file("cis_v1.2.0/docs/3.11.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_nacl_changes.sql")
   }
 
   check "3.12" {
-    title         = "3.12 Ensure a log metric filter and alarm exist for changes to network gateways (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for changes to network gateways (Scored)"
     doc           = file("cis_v1.2.0/docs/3.12.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_network_gateways.sql")
   }
 
   check "3.13" {
-    title         = "3.13 Ensure a log metric filter and alarm exist for route table changes (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for route table changes (Scored)"
     doc           = file("cis_v1.2.0/docs/3.13.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_route_table_changes.sql")
   }
 
   check "3.14" {
-    title         = "3.14 Ensure a log metric filter and alarm exist for VPC changes (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for VPC changes (Scored)"
     doc           = file("cis_v1.2.0/docs/3.14.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_vpc_changes.sql")

--- a/cis_v1.2.0/section_3.hcl
+++ b/cis_v1.2.0/section_3.hcl
@@ -3,63 +3,63 @@ policy "3" {
   doc   = file("cis_v1.2.0/docs/3.md")
 
   check "3.1" {
-    title         = "3.1 Ensure a log metric filter and alarm exist for unauthorized API calls (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for unauthorized API calls (Scored)"
     doc           = file("cis_v1.2.0/docs/3.1.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_unauthorized_api.sql")
   }
 
   check "3.2" {
-    title         = "3.2 Ensure a log metric filter and alarm exist for Management Console sign-in without MFA (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for Management Console sign-in without MFA (Scored)"
     doc           = file("cis_v1.2.0/docs/3.2.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_unauthorized_api.sql")
   }
 
   check "3.3" {
-    title         = "3.3  Ensure a log metric filter and alarm exist for usage of 'root' account (Score)"
+    title         = " Ensure a log metric filter and alarm exist for usage of 'root' account (Score)"
     doc           = file("cis_v1.2.0/docs/3.3.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_root_account.sql")
   }
 
   check "3.4" {
-    title         = "3.4 Ensure a log metric filter and alarm exist for IAM policy changes (Score)"
+    title         = "Ensure a log metric filter and alarm exist for IAM policy changes (Score)"
     doc           = file("cis_v1.2.0/docs/3.4.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_iam_policy_change.sql")
   }
 
   check "3.5" {
-    title         = "3.5 Ensure a log metric filter and alarm exist for CloudTrail configuration changes (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for CloudTrail configuration changes (Scored)"
     doc           = file("cis_v1.2.0/docs/3.5.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_cloudtrail_config_changes.sql")
   }
 
   check "3.6" {
-    title         = "3.6 Ensure a log metric filter and alarm exist for AWS Management Console authentication failures (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for AWS Management Console authentication failures (Scored)"
     doc           = file("cis_v1.2.0/docs/3.6.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_console_auth_failure.sql")
   }
 
   check "3.7" {
-    title         = "3.7 Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs (Scored)"
     doc           = file("cis_v1.2.0/docs/3.7.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_delete_customer_cmk.sql")
   }
 
   check "3.8" {
-    title         = "3.8 Ensure a log metric filter and alarm exist for S3 bucket policy changes (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for S3 bucket policy changes (Scored)"
     doc           = file("cis_v1.2.0/docs/3.8.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_s3_bucket_policy_change.sql")
   }
 
   check "3.9" {
-    title         = "3.9 Ensure a log metric filter and alarm exist for AWS Config configuration changes (Scored)"
+    title         = "Ensure a log metric filter and alarm exist for AWS Config configuration changes (Scored)"
     doc           = file("cis_v1.2.0/docs/3.9.md")
     expect_output = true
     query         = file("queries/cloudwatch/alarm_aws_config_changes.sql")

--- a/cis_v1.2.0/section_4.hcl
+++ b/cis_v1.2.0/section_4.hcl
@@ -8,19 +8,19 @@ policy "4" {
   }
 
   check "4.1" {
-    title = "4.1 Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 (Scored)"
+    title = "Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 (Scored)"
     doc   = file("cis_v1.2.0/docs/4.1.md")
     query = file("queries/ec2/no_broad_public_ingress_on_port_22.sql")
   }
 
   check "4.2" {
-    title = "4.2 Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 (Scored)"
+    title = "Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 (Scored)"
     doc   = file("cis_v1.2.0/docs/4.2.md")
     query = file("queries/ec2/no_broad_public_ingress_on_port_3389.sql")
   }
 
   check "4.3" {
-    title = "4.3  Ensure the default security group of every VPC restricts all traffic (Scored)"
+    title = " Ensure the default security group of every VPC restricts all traffic (Scored)"
     doc   = file("cis_v1.2.0/docs/4.3.md")
     query = file("queries/ec2/default_sg_no_access.sql")
   }


### PR DESCRIPTION
Duplicate output of control title (1.x):

```
    ✓   1.1  1.1 Avoid the use of 'root' account. Show used in last 30 days (Scored)            passed

    ❌  1.2  1.2 Ensure MFA is enabled for all IAM users that have a console password (Scored)  failed

    ❌  1.3  1.3 Ensure credentials unused for 90 days or greater are disabled (Scored)         failed 

```