### PR TITLE
chore: Explicitly define views everywhere they are used

### DIFF
--- a/cis_v1.2.0/policy.hcl
+++ b/cis_v1.2.0/policy.hcl
@@ -7,11 +7,6 @@ policy "cis-v1.20" {
     }
   }
 
-  view "aws_log_metric_filter_and_alarm" {
-    title = "AWS Log Metric Filter and Alarm"
-    query = file("queries/cloudwatch/log_metric_filter_and_alarm_view.sql")
-  }
-
   policy "1" {
     source = file("cis_v1.2.0/section_1.hcl")
   }

--- a/cis_v1.2.0/section_3.hcl
+++ b/cis_v1.2.0/section_3.hcl
@@ -2,6 +2,11 @@ policy "3" {
   title = "Section 3: Monitoring"
   doc   = file("cis_v1.2.0/docs/3.md")
 
+  view "aws_log_metric_filter_and_alarm" {
+    title = "AWS Log Metric Filter and Alarm"
+    query = file("queries/cloudwatch/log_metric_filter_and_alarm_view.sql")
+  }
+
   check "3.1" {
     title         = "Ensure a log metric filter and alarm exist for unauthorized API calls (Scored)"
     doc           = file("cis_v1.2.0/docs/3.1.md")

--- a/foundational_security/services/ec2.hcl
+++ b/foundational_security/services/ec2.hcl
@@ -1,6 +1,7 @@
 policy "ec2" {
   title = "EC2 controls"
   doc   = file("foundational_security/docs/ec2.md")
+
   view "aws_security_group_ingress_rules" {
     title = "Aggregates rules of security groups with ports and IPs including ipv6"
     query = file("queries/cq_views/aws_security_group_ingress_rules.sql")

--- a/pci_dss_v3.2.1/policy.hcl
+++ b/pci_dss_v3.2.1/policy.hcl
@@ -6,17 +6,6 @@ policy "pci-dss-v3.2.1" {
     }
   }
 
-  view "aws_log_metric_filter_and_alarm" {
-    title = "AWS Log Metric Filter and Alarm"
-    query = file("queries/cloudwatch/log_metric_filter_and_alarm_view.sql")
-  }
-
-
-  view "aws_security_group_ingress_rules" {
-    title = "Aggregates rules of security groups with ports and IPs including ipv6"
-    query = file("queries/cq_views/aws_security_group_ingress_rules.sql")
-  }
-
   policy "autoscaling" {
     title = "checks for autoscaling"
     check "1" {
@@ -76,6 +65,11 @@ policy "pci-dss-v3.2.1" {
   }
 
   policy "cloudwatch" {
+    view "aws_log_metric_filter_and_alarm" {
+      title = "AWS Log Metric Filter and Alarm"
+      query = file("queries/cloudwatch/log_metric_filter_and_alarm_view.sql")
+    }
+
     check "1" {
       title = "A log metric filter and alarm should exist for usage of the 'root' user"
       query = file("queries/cloudwatch/alarm_root_account.sql")


### PR DESCRIPTION
This is done in preparation for a cloudquery-core codechange that will limit scope of views to only the subpolicy
where they are defined.