### PR TITLE
fix: Add minimal documenation in place of empty '.md' files

### DIFF
--- a/foundational_security/docs/ec2.md
+++ b/foundational_security/docs/ec2.md
@@ -1,0 +1,3 @@
+# Overview 
+
+This section contains recommendations for configuring EC2 and related options.

--- a/foundational_security/docs/elbv2.md
+++ b/foundational_security/docs/elbv2.md
@@ -1,0 +1,3 @@
+# Overview 
+
+This section contains recommendations for configuring ELBv2 and related options.

--- a/foundational_security/docs/s3.md
+++ b/foundational_security/docs/s3.md
@@ -1,0 +1,3 @@
+# Overview 
+
+This section contains recommendations for configuring S3 and related options.


### PR DESCRIPTION
Having empty docs screws up a bit with the backend (indexer) and frontend (500 error when attempting to access their documentation).