### PR TITLE
fix: Lambda query

### DIFF
--- a/queries/lambda/lambda_functions_should_use_supported_runtimes.sql
+++ b/queries/lambda/lambda_functions_should_use_supported_runtimes.sql
@@ -4,4 +4,4 @@ SELECT account_id,
        runtime
 FROM aws_lambda_functions
 WHERE runtime NOT IN (SELECT name FROM aws_lambda_runtimes) 
-    AND code_repository_type <> 'ECR'
+    AND package_type <> 'Image'

--- a/queries/lambda/lambda_functions_should_use_supported_runtimes.sql
+++ b/queries/lambda/lambda_functions_should_use_supported_runtimes.sql
@@ -3,4 +3,5 @@ SELECT account_id,
        arn,
        runtime
 FROM aws_lambda_functions
-WHERE runtime NOT IN (SELECT name FROM aws_lambda_runtimes)
+WHERE runtime NOT IN (SELECT name FROM aws_lambda_runtimes) 
+    AND code_repository_type <> 'ECR'


### PR DESCRIPTION

Following the docs:
```
The AWS Config rule ignores functions that have a package type of Image.
```


https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-lambda-1