### PR TITLE
fix: Change version constraints from "~>" to ">="

### DIFF
--- a/cis_v1.2.0/policy.hcl
+++ b/cis_v1.2.0/policy.hcl
@@ -3,7 +3,7 @@ policy "cis-v1.20" {
   doc   = file("cis_v1.2.0/README.md")
   configuration {
     provider "aws" {
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 

--- a/foundational_security/policy.hcl
+++ b/foundational_security/policy.hcl
@@ -2,7 +2,7 @@ policy "foundational_security" {
   title = "AWS Foundational Security Best Practices controls"
   configuration {
     provider "aws" {
-      version = "~> v0.10.0"
+      version = ">= 0.10.0"
     }
   }
 

--- a/pci_dss_v3.2.1/policy.hcl
+++ b/pci_dss_v3.2.1/policy.hcl
@@ -2,7 +2,7 @@ policy "pci-dss-v3.2.1" {
   title = "PCI DSS V3.2.1"
   configuration {
     provider "aws" {
-      version = "~> v0.10.0"
+      version = ">= 0.10.0"
     }
   }
 

--- a/policy.hcl
+++ b/policy.hcl
@@ -3,7 +3,7 @@ policy "aws" {
   doc   = file("README.md")
   configuration {
     provider "aws" {
-      version = "~> 0.11.0"
+      version = ">= 0.10.0"
     }
   }
 

--- a/public_egress/policy.hcl
+++ b/public_egress/policy.hcl
@@ -3,7 +3,7 @@ policy "public-egress" {
 
   configuration {
     provider "aws" {
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
   view "aws_security_group_egress_rules" {

--- a/publicly_available/policy.hcl
+++ b/publicly_available/policy.hcl
@@ -3,7 +3,7 @@ policy "public-ips" {
 
   configuration {
     provider "aws" {
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 


### PR DESCRIPTION
Policies shouldn't break by default every new major release.

(Because all cloudquewry releases are 0.x.y, by "major" in above sentence I mean the "x").